### PR TITLE
Use Ty for Python type checking

### DIFF
--- a/.github/workflows/quality_control.yaml
+++ b/.github/workflows/quality_control.yaml
@@ -106,7 +106,7 @@ jobs:
         with:
           enable-cache: false
 
-      - name: Run ty
+      - name: Run Ty
         run: uv run ty check
 
       - name: Run Ruff

--- a/.github/workflows/quality_control.yaml
+++ b/.github/workflows/quality_control.yaml
@@ -106,8 +106,8 @@ jobs:
         with:
           enable-cache: false
 
-      - name: Run Pyright
-        run: uv run pyright
+      - name: Run ty
+        run: uv run ty check
 
       - name: Run Ruff
         run: uv run ruff check .

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,9 @@
+{
+  "recommendations": [
+    "rust-lang.rust-analyzer",
+    "charliermarsh.ruff",
+    "astral-sh.ty",
+    "tamasfe.even-better-toml",
+    "dart-code.flutter"
+  ]
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,17 +4,17 @@
 # `uv run automate [command_type]`.
 
 [dependency-groups]
-dev = ["ruff", "pyright"]
+dev = ["ruff", "ty"]
 
 [tool.uv.workspace]
 members = ["automate", "documentation"]
 
+[tool.ty.rules]
+all = "error"
+
 [tool.ruff.lint]
 select = ["ALL"]
 ignore = ["TC", "BLE", "S602"]
-
-[tool.pyright]
-typeCheckingMode = "strict"
 
 [tool.ruff.lint.per-file-ignores]
 "documentation/**/*.py" = ["A001"]

--- a/rust_crate_cli/src/tool/webassembly.rs
+++ b/rust_crate_cli/src/tool/webassembly.rs
@@ -63,11 +63,11 @@ fn install_wasm_toolchain() -> Result<(), SetupError> {
     .output()?
     .capture_err()?;
   Command::new("cargo")
-    .args(["install", "wasm-pack"])
+    .args(["install", "--locked", "wasm-pack"])
     .output()?
     .capture_err()?;
   Command::new("cargo")
-    .args(["install", "wasm-bindgen-cli"])
+    .args(["install", "--locked", "wasm-bindgen-cli"])
     .output()?
     .capture_err()?;
   Ok(())


### PR DESCRIPTION
## Changes

This PR removes Pyright and uses Ty for Python type checking

## Before Committing

```
dart analyze flutter_package --fatal-infos
dart format .
cargo fmt
cargo clippy --fix --allow-dirty
```
